### PR TITLE
Reactivate the foreign_key_checks after the DELETE FROM {table} in Db::flush()

### DIFF
--- a/lib/db.php
+++ b/lib/db.php
@@ -27,7 +27,9 @@ class Db {
 
     public static function flush() {
         foreach(self::$connection->query("SHOW TABLES") as $t) {
-            self::$connection->query("SET foreign_key_checks=0; DELETE FROM " . $t[0] . "");
+            // Disable foreign key cheks, drop the tables then re activate the foreign key check.
+            // Without the re activation, the "ON DELETE CASCADE" wont work, since the foreign key check is disabled.
+            self::$connection->query("SET foreign_key_checks=0; DELETE FROM " . $t[0] . "; SET foreign_key_checks=1;");
         }
     }
 }

--- a/lib/db.php
+++ b/lib/db.php
@@ -27,8 +27,8 @@ class Db {
 
     public static function flush() {
         foreach(self::$connection->query("SHOW TABLES") as $t) {
-            // Disable foreign key cheks, drop the tables then re activate the foreign key check.
-            // Without the re activation, the "ON DELETE CASCADE" wont work, since the foreign key check is disabled.
+            // Disable foreign key checks, empty the tables then re activate the foreign key checks.
+            // Without the re activation, the "ON DELETE CASCADE" won't work, since the foreign key checks are disabled.
             self::$connection->query("SET foreign_key_checks=0; DELETE FROM " . $t[0] . "; SET foreign_key_checks=1;");
         }
     }


### PR DESCRIPTION
A cause de ça, les suppressions en cascade ne fonctionnaient pas dans les tests unitaires, puisque vous ne réactiviez jamais la vérification des clés étrangères. 